### PR TITLE
fix: restore SVG capture framerate and skip raster work for SVG-only output

### DIFF
--- a/src/VcrSharp.Core/Session/SessionOptions.cs
+++ b/src/VcrSharp.Core/Session/SessionOptions.cs
@@ -309,6 +309,26 @@ public class SessionOptions
     public List<string> OutputFiles { get; set; } = new();
 
     /// <summary>
+    /// Whether the configured outputs require per-frame raster (PNG) capture. SVG output is
+    /// rendered from lightweight terminal-content snapshots, so an SVG-only recording can skip
+    /// the expensive per-frame canvas screenshot entirely. Returns true if any output is a
+    /// non-SVG animation/image (GIF, MP4, WebM, PNG, or a frames directory).
+    /// </summary>
+    public bool RequiresRasterFrames
+    {
+        get
+        {
+            foreach (var file in OutputFiles)
+            {
+                if (!".svg".Equals(System.IO.Path.GetExtension(file), System.StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Gets or sets environment variables to set in the shell.
     /// </summary>
     public Dictionary<string, string> Environment { get; set; } = new();

--- a/src/VcrSharp.Infrastructure/Playwright/TerminalPage.cs
+++ b/src/VcrSharp.Infrastructure/Playwright/TerminalPage.cs
@@ -683,30 +683,25 @@ public class TerminalPage : ITerminalPage
     }
 
     /// <summary>
-    /// Captures a canvas element as PNG bytes using GPU-accelerated canvas.toBlob().
-    /// Uses async blob API which is more efficient than toDataURL() (no base64 overhead).
+    /// Captures a canvas element as PNG bytes using the synchronous <c>canvas.toDataURL()</c> API.
     /// </summary>
+    /// <remarks>
+    /// Deliberately synchronous. The async <c>canvas.toBlob()</c> path completes via a FileReader
+    /// callback, and on a headless/backgrounded page Chromium throttles those async callback
+    /// wake-ups to ~1 Hz. That capped frame capture at ~1 fps regardless of the configured
+    /// framerate (each grab took ~1000 ms), producing visibly jerky animations. <c>toDataURL()</c>
+    /// returns within the synchronous Evaluate call (~5 ms here) and is not subject to that
+    /// throttle. The extra base64 cost is negligible for terminal-sized canvases.
+    /// </remarks>
     /// <param name="selector">CSS selector for the canvas element.</param>
     /// <returns>PNG image bytes.</returns>
     private async Task<byte[]> CaptureCanvasLayerAsync(string selector)
     {
         var canvas = _page.Locator(selector);
 
-        // Use canvas.toBlob() for maximum performance (MDN recommended, more efficient than toDataURL)
-        var base64Data = await canvas.EvaluateAsync<string>("""
-
-                                                            canvas => new Promise(resolve => {
-                                                                canvas.toBlob(blob => {
-                                                                    const reader = new FileReader();
-                                                                    reader.onloadend = () => {
-                                                                        // Extract base64 data without 'data:image/png;base64,' prefix
-                                                                        resolve(reader.result.split(',')[1]);
-                                                                    };
-                                                                    reader.readAsDataURL(blob);
-                                                                }, 'image/png');
-                                                            })
-
-                                                            """);
+        // Synchronous toDataURL returns "data:image/png;base64,<...>"; strip the prefix and decode.
+        var base64Data = await canvas.EvaluateAsync<string>(
+            "canvas => canvas.toDataURL('image/png').split(',')[1]");
 
         return Convert.FromBase64String(base64Data);
     }

--- a/src/VcrSharp.Infrastructure/Recording/FrameCapture.cs
+++ b/src/VcrSharp.Infrastructure/Recording/FrameCapture.cs
@@ -126,23 +126,31 @@ public class FrameCapture : IFrameCapture, IAsyncDisposable
         var frameNumber = _state.FramesCaptured + 1;
         var timestamp = Stopwatch.Elapsed;
 
-        // Capture both PNG layers and terminal content in parallel for better performance
-        // Skip cursor layer if DisableCursor is enabled
-        var captureLayersTask = _terminalPage.CaptureLayersAsync(captureCursor: !_options.DisableCursor);
+        // Always capture the lightweight terminal-content snapshot (used by the SVG encoder).
+        // The expensive per-frame PNG layers are only needed by raster outputs (GIF/MP4/WebM/PNG/
+        // frames), so an SVG-only recording skips them entirely. Capturing them throttled the loop
+        // to ~1 fps; the content read alone is a few ms.
         var terminalContentTask = _terminalPage.GetTerminalContentWithStylesAsync();
 
-        await Task.WhenAll(captureLayersTask, terminalContentTask);
+        if (_options.RequiresRasterFrames)
+        {
+            // Capture PNG layers and terminal content in parallel for better performance.
+            // Skip cursor layer if DisableCursor is enabled.
+            var captureLayersTask = _terminalPage.CaptureLayersAsync(captureCursor: !_options.DisableCursor);
+            await Task.WhenAll(captureLayersTask, terminalContentTask);
 
-        var (textBytes, cursorBytes) = captureLayersTask.Result;
-        var terminalContent = terminalContentTask.Result;
+            var (textBytes, cursorBytes) = captureLayersTask.Result;
 
-        // Get file paths for both layers
-        var textPath = _storage.GetFrameLayerPath(frameNumber, "text");
-        var cursorPath = _storage.GetFrameLayerPath(frameNumber, "cursor");
+            // Get file paths for both layers
+            var textPath = _storage.GetFrameLayerPath(frameNumber, "text");
+            var cursorPath = _storage.GetFrameLayerPath(frameNumber, "cursor");
 
-        // Enqueue for background writing (non-blocking)
-        await _writeQueue.EnqueueAsync(textPath, textBytes);
-        await _writeQueue.EnqueueAsync(cursorPath, cursorBytes);
+            // Enqueue for background writing (non-blocking)
+            await _writeQueue.EnqueueAsync(textPath, textBytes);
+            await _writeQueue.EnqueueAsync(cursorPath, cursorBytes);
+        }
+
+        var terminalContent = await terminalContentTask;
 
         // Record terminal content snapshot for SVG/text-based outputs
         var snapshot = new TerminalContentSnapshot

--- a/src/VcrSharp.Infrastructure/Rendering/Encoders/SvgEncoder.cs
+++ b/src/VcrSharp.Infrastructure/Rendering/Encoders/SvgEncoder.cs
@@ -24,8 +24,9 @@ public class SvgEncoder(SessionOptions options, FrameStorage storage) : EncoderB
 
     public override async Task<string> RenderAsync(string outputPath, IProgress<string>? progress = null, CancellationToken cancellationToken = default)
     {
-        ValidateFramesExist();
-
+        // Note: SVG is built from terminal-content snapshots, not PNG frame files, so we validate
+        // snapshots below rather than calling the PNG-based ValidateFramesExist() — an SVG-only
+        // recording deliberately captures no raster frames.
         progress?.Report("Loading terminal content snapshots...");
 
         // Get terminal content snapshots

--- a/src/VcrSharp.Infrastructure/Rendering/VideoEncoder.cs
+++ b/src/VcrSharp.Infrastructure/Rendering/VideoEncoder.cs
@@ -52,8 +52,9 @@ public class VideoEncoder
             throw new InvalidOperationException("No output files specified. VideoEncoder.RenderAsync should only be called when output files are configured.");
         }
 
-        var frameCount = _storage.CountFrames();
-        if (frameCount == 0)
+        // SVG output is rendered from terminal-content snapshots rather than PNG frame files, so an
+        // SVG-only recording legitimately has zero raster frames. Only fail when neither exists.
+        if (_storage.CountFrames() == 0 && _storage.GetTerminalSnapshots().Count == 0)
         {
             throw new InvalidOperationException("No frames captured to render");
         }

--- a/src/VcrSharp.Infrastructure/Session/VcrSession.cs
+++ b/src/VcrSharp.Infrastructure/Session/VcrSession.cs
@@ -182,33 +182,43 @@ public class VcrSession : IAsyncDisposable
             // 18. Stop frame capture
             await _frameCapture.StopAsync();
 
-            // 19. Trim frames based on activity frame numbers
+            // 19. Trim frames based on activity frame numbers.
+            // Always record the trimmed range so the SVG encoder can window its snapshots, but only
+            // physically trim/renumber the PNG layer files when a raster output actually needs them
+            // (an SVG-only recording never wrote any PNG frames).
             var frameTrimmer = new FrameTrimmer(_options, _state);
             var frameRange = frameTrimmer.CalculateFrameRange();
             if (frameRange.HasValue)
             {
-                progress?.Report("Trimming frames based on activity...");
-
                 // Store the trimmed frame range in options so encoders can access it
                 // These are the ORIGINAL frame numbers before renumbering
                 _options.TrimmedFirstFrame = frameRange.Value.firstFrame;
                 _options.TrimmedLastFrame = frameRange.Value.lastFrame;
 
-                frameTrimmer.TrimFrames(_frameStorage.FrameDirectory, frameRange.Value.firstFrame, frameRange.Value.lastFrame);
-                frameTrimmer.RenumberFrames(_frameStorage.FrameDirectory);
+                if (_options.RequiresRasterFrames)
+                {
+                    progress?.Report("Trimming frames based on activity...");
 
-                // Update frame count and elapsed time after trimming
-                var remainingFrames = Directory.GetFiles(_frameStorage.FrameDirectory, "frame-text-*.png").Length;
-                _state.FramesCaptured = remainingFrames;
+                    frameTrimmer.TrimFrames(_frameStorage.FrameDirectory, frameRange.Value.firstFrame, frameRange.Value.lastFrame);
+                    frameTrimmer.RenumberFrames(_frameStorage.FrameDirectory);
 
-                // Recalculate elapsed time based on trimmed frame count and framerate
-                _state.ElapsedTime = TimeSpan.FromSeconds(remainingFrames / (double)_options.Framerate);
+                    // Update frame count and elapsed time after trimming
+                    var remainingFrames = Directory.GetFiles(_frameStorage.FrameDirectory, "frame-text-*.png").Length;
+                    _state.FramesCaptured = remainingFrames;
+
+                    // Recalculate elapsed time based on trimmed frame count and framerate
+                    _state.ElapsedTime = TimeSpan.FromSeconds(remainingFrames / (double)_options.Framerate);
+                }
             }
 
-            // 20. Generate frames manifest with variable durations
-            progress?.Report("Generating frames manifest...");
-            var defaultFrameInterval = TimeSpan.FromSeconds(1.0 / _options.Framerate);
-            _frameStorage.GenerateFramesManifest(defaultFrameInterval);
+            // 20. Generate frames manifest with variable durations (only needed by the raster/FFmpeg
+            // encoders; the SVG encoder works directly from terminal-content snapshots).
+            if (_options.RequiresRasterFrames)
+            {
+                progress?.Report("Generating frames manifest...");
+                var defaultFrameInterval = TimeSpan.FromSeconds(1.0 / _options.Framerate);
+                _frameStorage.GenerateFramesManifest(defaultFrameInterval);
+            }
 
             stopwatch.Stop();
 


### PR DESCRIPTION
## Summary

Two related fixes to terminal-content capture:

1. **Restore capture framerate.** The async `canvas.toBlob()` capture path completes via a `FileReader` callback, which Chromium throttles to ~1 Hz on a headless/backgrounded page. That capped frame capture at ~1 fps regardless of the configured `Framerate`, producing visibly jerky animations. Switching to the synchronous `canvas.toDataURL()` API returns within the `Evaluate` call (~5 ms) and is not subject to the throttle. The extra base64 cost is negligible for terminal-sized canvases.

2. **Skip raster work for SVG-only recordings.** SVG output is rendered from lightweight terminal-content snapshots rather than PNG frame files, so an SVG-only recording can skip per-frame PNG capture, trimming/renumbering, and the frames manifest entirely.

## Changes

- Add `SessionOptions.RequiresRasterFrames` — true when any configured output is a non-SVG animation/image (GIF/MP4/WebM/PNG/frames directory).
- `FrameCapture` only grabs the expensive PNG layers when raster output needs them; the terminal-content snapshot is always captured.
- `VcrSession` only trims/renumbers frames and writes the manifest for raster outputs, but always records the trimmed range so the SVG encoder can window its snapshots.
- `SvgEncoder` / `VideoEncoder` validate terminal-content snapshots instead of PNG frames, so an SVG-only recording with zero raster frames no longer errors out.

## Test plan

- [x] `dotnet build VcrSharp.sln` succeeds (0 warnings, 0 errors)
- [ ] Record an SVG-only tape and confirm smooth framerate + no "No frames captured" error
- [ ] Record a GIF/MP4 tape and confirm raster path still trims and encodes as before